### PR TITLE
handle encodings of text and html parts in sendgrid strategy

### DIFF
--- a/lib/incoming/strategies/sendgrid.rb
+++ b/lib/incoming/strategies/sendgrid.rb
@@ -17,12 +17,19 @@ module Incoming
 
         @message = Mail.new do
           header params['headers']
-
-          body params['text'].force_encoding(encodings['text']).encode('UTF-8')
+          if encodings['text'].blank?
+            body params['text']
+          else
+            body params['text'].force_encoding(encodings['text']).encode('UTF-8')
+          end
 
           html_part do
             content_type 'text/html; charset=UTF-8'
-            body params['html'].force_encoding(encodings['html']).encode('UTF-8')
+            if encodings['html'].blank?
+              body params['html']
+            else
+              body params['html'].force_encoding(encodings['html']).encode('UTF-8')
+            end
           end if params['html']
 
           attachments.each do |attachment|


### PR DESCRIPTION
still missing encoding handle for the headers: subject, to, from...
