### PR TITLE
Sendgrid content transfer encoding

### DIFF
--- a/lib/incoming/strategies/sendgrid.rb
+++ b/lib/incoming/strategies/sendgrid.rb
@@ -8,7 +8,6 @@ module Incoming
       def initialize(request)
         params = request.params.dup
 
-        # TODO: Properly handle encodings
         encodings = JSON.parse(params['charsets'])
 
         attachments = 1.upto(params['attachments'].to_i).map do |num|
@@ -17,6 +16,8 @@ module Incoming
 
         @message = Mail.new do
           header params['headers']
+          header['Content-Transfer-Encoding'] = nil
+
           if encodings['text'].blank?
             body params['text']
           else

--- a/spec/incoming/strategies/sendgrid_spec.rb
+++ b/spec/incoming/strategies/sendgrid_spec.rb
@@ -36,5 +36,19 @@ describe Incoming::Strategies::SendGrid do
     its('attachments.first.read') { should eq 'hello world' }
     its('attachments.last.filename') { should eq 'bar.txt' }
     its('attachments.last.read') { should eq 'hullo world' }
+
+    context "with base64 Content-Transfer-Encoding" do
+
+      let(:params){
+        {
+          'charsets' => '{"from": "UTF-8", "subject": "UTF-8", "text": "UTF-8", "to": "UTF-8"}',
+          'headers' => ["Content-Transfer-Encoding: base64", "Content-Type: text/plain; charset=UTF-8"].join("\r\n"),
+          'text' => 'We should do that again sometime.',
+          'attachments' => '0',
+        }
+      }
+
+      its('body.decoded') { should eq 'We should do that again sometime.' }
+    end
   end
 end


### PR DESCRIPTION
Fix #10 by removing the Content-Transfer-Encoding header.
